### PR TITLE
Adds Phase 5: Implementation to the Skill; Adds TDD section. Connects…

### DIFF
--- a/skills/design-driven-dev/SKILL.md
+++ b/skills/design-driven-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: design-driven-dev
-description: Guide for design-driven development. Consult for ALL code changes. New features use full workflow (HLD → LLD → EARS → Plan). Bug fixes skip doc creation but still verify intent coherence—check that existing specs, tests, and code align before changing anything.
+name: linked-intent-driven-dev
+description: Guide for linked-intent-driven development. Consult for ALL code changes. New features use full workflow (HLD → LLD → EARS → Plan). Bug fixes skip doc creation but still verify intent coherence—check that existing specs, tests, and code align before changing anything.
 ---
 
 # Design-Driven Development
@@ -145,7 +145,15 @@ Before implementing (or resuming implementation), verify coherence:
 - Do the tests trace to current EARS?
 - If drift is detected, fix the docs first—then implement.
 
-## Code Annotation Pattern
+## Phase 5: Implementation
+
+Proceed through each implementation phase, one EARS spec at a time. 
+
+### Test-Driven Development
+
+For each EARS spec, use a test-driven development approach. Write the tests and then stop and get user approval before proceeding. Then write the implementation so that the tests pass. Stop and get user approval before proceeding to the next EARS spec.
+
+### Code Annotation Pattern
 
 Annotate code with `@spec` comments linking to EARS IDs:
 


### PR DESCRIPTION
… Code Annotation to Phase 5.

I'm not sure how required the TDD mention is, but I found this skill had Claude moving one component/class at a time, which was too much code to review at a go. This tries to force it into one EARS spec at a time.

I've not tested this yet, so maybe this should be a Draft?